### PR TITLE
Add auto selection of file under cursor

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -105,10 +105,12 @@ local get_selection_details = ya.sync(function()
 				"[kdeconnect-send] Nothing was selected. Will now use the hovered file under cursor: ",
 				tostring(hovered_file.url)
 			)
-			if hovered_file.cha and hovered_file.cha.is_dir then
-				return {}, true -- If directory was selected, return empty list, but also set the directory_selected var to true
+			-- For safety, only treat as a regular file when cha.is_dir is explicitly false.
+			-- If cha is missing or is_dir is nil/true, treat as a (potential) directory.
+			if hovered_file.cha and hovered_file.cha.is_dir == false then
+				return { tostring(hovered_file.url) }, false -- Regular file hovered
 			else
-				return { tostring(hovered_file.url) }, false -- If not, then return the hovered file
+				return {}, true -- Directory or indeterminate entry: mark directory_selected
 			end
 		end
 		return {}, false

--- a/main.lua
+++ b/main.lua
@@ -99,7 +99,18 @@ local get_selection_details = ya.sync(function()
 		break
 	end
 	if selection_empty then
-		ya.dbg("[kdeconnect-send] Selection map is empty.")
+		local hovered_file = cx.active.current.hovered -- Use the hovered file under cursor
+		if hovered_file then
+			ya.dbg(
+				"[kdeconnect-send] Nothing was selected. Will now use the hovered file under cursor: ",
+				tostring(hovered_file.url)
+			)
+			if hovered_file.cha and hovered_file.cha.is_dir then
+				return {}, true -- If directory was selected, return empty list, but also set the directory_selected var to true
+			else
+				return { tostring(hovered_file.url) }, false -- If not, then return the hovered file
+			end
+		end
 		return {}, false
 	end
 


### PR DESCRIPTION
Using the active.current.hovered API to auto select the current file under cursor (ignoring directory) and send it.

This aligns with the usual behavior of [ripdrag](https://github.com/nik012003/ripdrag) integration with yazi (which i reguarly use).